### PR TITLE
Apply attribute node['squid']['port'] to squid.conf template

### DIFF
--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -50,7 +50,7 @@ http_access deny all
 
 icp_access allow localnet
 icp_access deny all
-http_port 3128
+http_port <%= node['squid']['port'] %>
 
 hierarchy_stoplist cgi-bin ?
 access_log <%= node['squid']['log_dir'] %>/access.log squid


### PR DESCRIPTION
The listen port was hard-corded in squid.conf.erb. It should be node['squid']['port'].
