### PR TITLE
Make configuration of binds more flexible; add support for configuring data bag names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Gemfile.lock
 
 .bundle/
 .cache/
+.idea/
 .kitchen/
 .vagrant/
 .vagrant.d/

--- a/README.md
+++ b/README.md
@@ -6,15 +6,25 @@ Configures squid as a caching proxy.
 Recipes
 -------
 ### default
-The default recipe installs squid and sets up simple proxy caching. As of now, the options you may change are the port (`node['squid']['port']`) and the network the caching proxy is available on the subnet from `node.ipaddress` (ie. "192.168.1.0/24") but may be overridden with `node['squid']['network']`. The size of objects allowed to be stored has been bumped up to allow for caching of installation files.
+The default recipe installs squid and sets up simple proxy caching. To configure where the squid service listens for
+requests you have a few options. By default, this cookbook will configure squid to listen on all available interfaces
+on port 3128 (`node['squid']['port']`). To specify an interface to bind to, use the `node['squid']['listen_interface']`
+attribute. If this is defined, squid will only listen on port 3128 on the specified interface, whose IP address is
+discovered automatically. If you need a more custom setup, define `node['squid']['http_binds']` as a string or a list
+of binds, each of which can be either a port or ipaddress:port format.
+
+The size of objects allowed to be stored has been bumped up to allow for caching of installation files.
 
 
 Usage
 -----
-Include the squid recipe on the server. Other nodes may search for this node as their caching proxy and use the `node.ipaddress` and `node['squid']['port']` to point at it.
+Include the squid recipe on the server.
 
-Databags are able to be used for storing host & url acls and also which hosts/nets are able to access which hosts/url
-
+Databags are able to be used for storing host & url acls and also which hosts/nets are able to access which hosts/url.
+By default, this cookbook looks for databags named `squid_urls`, `squid_hosts`, and `squid_acls` to configure allowed
+URLs and hosts, and ACLs respectively (as described below). You may wish to change the names of the databags in the
+event you wish to run multiple squids with different configs. To do this, set the attributes
+`node['squid']['urls_data_bag_name']`, `node['squid']['hosts_data_bag_name']`, and `node['squid']['acls_data_bag_name']`.
 
 Example Databags
 ----------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,11 +19,17 @@
 # limitations under the License.
 #
 
+default['squid']['http_binds'] = nil
 default['squid']['port'] = 3128
-default['squid']['network'] = nil
+default['squid']['listen_interface'] = nil
+default['squid']['hosts_data_bag_name'] = 'squid_hosts'
+default['squid']['urls_data_bag_name'] = 'squid_urls'
+default['squid']['acls_data_bag_name'] = 'squid_acls'
+default['squid']['cache_mem'] = "2048"
+
+
 default['squid']['timeout'] = "10"
 default['squid']['opts'] = ""
-
 default['squid']['package'] = "squid"
 default['squid']['version'] = "3.1"
 default['squid']['config_dir'] = "/etc/squid"
@@ -32,9 +38,6 @@ default['squid']['log_dir'] = "/var/log/squid"
 default['squid']['cache_dir'] = "/var/spool/squid"
 default['squid']['coredump_dir'] = "/var/spool/squid"
 default['squid']['service_name'] = "squid"
-
-default['squid']['listen_interface'] = "eth0"
-default['squid']['cache_mem'] = "2048"
 
 case platform_family
 

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,45 +1,45 @@
 # load them databags.
-def squid_load_host_acl
+def squid_load_host_acl data_bag_name
   host_acl = []
   begin
-    data_bag("squid_hosts").each do |bag|
-      group = data_bag_item("squid_hosts",bag)
+    data_bag(data_bag_name).each do |bag|
+      group = data_bag_item(data_bag_name, bag)
       group['net'].each do |host|
         host_acl.push [group['id'],group['type'],host]
       end
     end
   rescue
-    Chef::Log.info "no 'squid_hosts' data bag"
+    Chef::Log.info "no such data bag [" + data_bag_name + "]"
   end
   host_acl
 end
 
-def squid_load_url_acl
+def squid_load_url_acl data_bag_name
   url_acl = []
   begin
-    data_bag("squid_urls").each do |bag|
-      group = data_bag_item("squid_urls",bag)
+    data_bag(data_bag_name).each do |bag|
+      group = data_bag_item(data_bag_name, bag)
       group['urls'].each do |url|
         url_acl.push [group['id'],url]
       end
     end
   rescue
-    Chef::Log.info "no 'squid_urls' data bag"
+    Chef::Log.info "no such data bag [" + data_bag_name + "]"
   end
   url_acl
 end
 
-def squid_load_acls
+def squid_load_acls data_bag_name
   acls = []
   begin
-    data_bag("squid_acls").each do |bag|
-      group = data_bag_item("squid_acls",bag)
+    data_bag(data_bag_name).each do |bag|
+      group = data_bag_item(data_bag_name, bag)
       group['acl'].each do |acl|
         acls.push [acl[1],group['id'],acl[0]]
       end
     end
   rescue
-    Chef::Log.info "no 'squid_acls' data bag"
+    Chef::Log.info "no such data bag [" + data_bag_name + "]"
   end
   acls
 end

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -1,13 +1,15 @@
 # This file generated from a Chef template.
 # squid/templates/default.squid.conf.erb
 
+# binds
+<% @http_binds.each do |bind| -%>
+http_port <%= bind %>
+<% end -%>
+
 <%= "acl all src" if node['squid']['version'].to_i <3 %>
 acl manager proto cache_object
 acl localhost src 127.0.0.1/32
 acl to_localhost dst 127.0.0.0/8 0.0.0.0/32
-acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
-acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
-acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
 acl SSL_ports port 443		# https
 acl SSL_ports port 563		# snews
 acl SSL_ports port 873		# rsync
@@ -45,12 +47,9 @@ http_access deny purge
 http_access deny !Safe_ports
 http_access deny CONNECT !SSL_ports
 http_access allow localhost
-http_access allow localnet
 http_access deny all
 
-icp_access allow localnet
 icp_access deny all
-http_port <%= node['squid']['port'] %>
 
 hierarchy_stoplist cgi-bin ?
 access_log <%= node['squid']['log_dir'] %>/access.log squid


### PR DESCRIPTION
A few changes:
- Make configuration of binds more flexible (default behavior was listen on all interfaces for the specified port)
- Add support for configuring data bag names (default names are unchanged for BC; allows multiple squid deployments per environment)
- Removed allow on localnets by default - some people deploy to cloud environments where 10/8 is used for private networks (like in Rackspace)
