### PR TITLE
Add support for ubuntu 13

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -58,7 +58,7 @@ when 'debian'
       set['squid']['config_file'] = '/etc/squid/squid.conf'
       set['squid']['service_name'] = 'squid'
 
-    elsif node['platform_version'] == '12.04'
+    elsif node['platform_version'] == '12.04' || node['platform_version'] =~ /13./
       set['squid']['package'] = 'squid3'
       set['squid']['version'] = '3.1'
       set['squid']['config_dir'] = '/etc/squid3'


### PR DESCRIPTION
The squid apt package actually installs squid3.

This is handled on ubuntu 12.04 through the default attributes. 
The patch enable these settings on ubuntu 13.
