### PR TITLE
Allow multiple http_port entries in squid.conf

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-default['squid']['port'] = [3128]
+default['squid']['port'] = 3128
 default['squid']['network'] = nil
 default['squid']['timeout'] = '10'
 default['squid']['opts'] = ''

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -56,8 +56,12 @@ http_access deny all
 
 icp_access allow localnet
 icp_access deny all
-<% node['squid']['port'].each do |port| %>
+<% if node['squid']['port'].kind_of?(Array) %>
+  <% node['squid']['port'].each do |port| %>
 http_port <%= port %>
+  <% end %>
+<% else %>
+http_port <%= node['squid']['port'] %>
 <% end %>
 
 hierarchy_stoplist cgi-bin ?


### PR DESCRIPTION
This PR is to allow the configuration of multiple ports in squid.conf.  My use case is I'm migrating from an old proxy that uses a different port...I want to bring up squid on it's default port and also  the port the old proxy used, allowing me to just change the DNS to point to the new proxy and clients don't need to know the new port number.  Then I can take my time migrating the clients to the new port.

There are also cases for using different ports in acl and http_access rules.

This could potentially be a breaking change for anyone who uses search to find the node['squid']['port'] to set their proxy on other nodes.
