### PR TITLE
Make ACL Element configurable per ACL, defaults back to url_regex

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ default['squid']['log_dir'] = '/var/log/squid'
 default['squid']['cache_dir'] = '/var/spool/squid'
 default['squid']['coredump_dir'] = '/var/spool/squid'
 default['squid']['service_name'] = 'squid'
+default['squid']['acl_element'] = 'url_regex'
 
 default['squid']['listen_interface'] = node['network']['interfaces'].dup.reject { |k, v| k == 'lo' }.keys.first
 default['squid']['cache_mem'] = '2048'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -20,7 +20,7 @@ def squid_load_url_acl
     data_bag('squid_urls').each do |bag|
       group = data_bag_item('squid_urls', bag)
       group['urls'].each do |url|
-        url_acl.push [group['id'], url]
+        url_acl.push [group['id'], group.has_key?('element') ? group['element'] : node['squid']['acl_element'], url]
       end
     end
   rescue

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -38,7 +38,7 @@ acl CONNECT method CONNECT
 acl <%= host[0] %> <%= host[1] %> <%= host[2] %>
 <% end %>
 <% @url_acl.each do |url| %>
-acl <%= url[0] %> url_regex <%= url[1] %>
+acl <%= url[0] %> <%= url[1] %> <%= url[2] %>
 <% end %>
 <% @acls.each do |acl| %>
 http_access <%= acl[0] %> <%= acl[1] %> <%= acl[2] %>


### PR DESCRIPTION
This change makes is possible to use all the match elements documented at http://wiki.squid-cache.org/SquidFaq/SquidAcl#ACL_elements

The element can be specified per squid_urls data bag item. If it's not specified then it uses the default value which is still url_regex, but can also be changed.
