### PR TITLE
Add specific squid ipaddress default attribute.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default['squid']['coredump_dir'] = '/var/spool/squid'
 default['squid']['service_name'] = 'squid'
 default['squid']['acl_element'] = 'url_regex'
 
+default['squid']['ipaddress'] = node['ipaddress']
 default['squid']['listen_interface'] = node['network']['interfaces'].dup.reject { |k, v| k == 'lo' }.keys.first
 default['squid']['cache_mem'] = '2048'
 default['squid']['cache_size'] = '100'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@
 #
 
 # variables
-ipaddress = node['ipaddress']
+ipaddress = node['squid']['ipaddress']
 listen_interface = node['squid']['listen_interface']
 version = node['squid']['version']
 netmask = node['network']['interfaces'][listen_interface]['addresses'][ipaddress]['netmask']


### PR DESCRIPTION
 Removes node['ipaddress'] as the only way to get the ipaddress.
