### PR TITLE
enable using variable databag names for acls, hosts and urls

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,10 @@ default['squid']['timeout'] = '10'
 default['squid']['opts'] = ''
 default['squid']['directives'] = []
 
+default['squid']['acls_databag_name'] = "squid_acls"
+default['squid']['hosts_databag_name'] = "squid_hosts"
+default['squid']['urls_databag_name'] = "squid_urls"
+
 default['squid']['package'] = 'squid'
 default['squid']['version'] = '3.1'
 default['squid']['config_dir'] = '/etc/squid'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,45 +1,45 @@
 # load them databags.
-def squid_load_host_acl
+def squid_load_host_acl(databag_name)
   host_acl = []
   begin
-    data_bag('squid_hosts').each do |bag|
-      group = data_bag_item('squid_hosts', bag)
+    data_bag(databag_name).each do |bag|
+      group = data_bag_item(databag_name, bag)
       group['net'].each do |host|
         host_acl.push [group['id'], group['type'], host]
       end
     end
   rescue
-     Chef::Log.info "no 'squid_hosts' data bag"
+     Chef::Log.info "no '#{databag_name}' data bag"
   end
   host_acl
 end
 
-def squid_load_url_acl
+def squid_load_url_acl(databag_name)
   url_acl = []
   begin
-    data_bag('squid_urls').each do |bag|
-      group = data_bag_item('squid_urls', bag)
+    data_bag(databag_name).each do |bag|
+      group = data_bag_item(databag_name, bag)
       group['urls'].each do |url|
         url_acl.push [group['id'], group.has_key?('element') ? group['element'] : node['squid']['acl_element'], url]
       end
     end
   rescue
-    Chef::Log.info "no 'squid_urls' data bag"
+    Chef::Log.info "no '#{databag_name}' data bag"
   end
   url_acl
 end
 
-def squid_load_acls
+def squid_load_acls(databag_name)
   acls = []
   begin
-    data_bag('squid_acls').each do |bag|
-      group = data_bag_item('squid_acls', bag)
+    data_bag(databag_name).each do |bag|
+      group = data_bag_item(databag_name, bag)
       group['acl'].each do |acl|
         acls.push [acl[1], group['id'], acl[0]]
       end
     end
   rescue
-    Chef::Log.info "no 'squid_acls' data bag"
+    Chef::Log.info "no '#{databag_name}' data bag"
   end
   acls
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@getchef.com'
 license          'Apache 2.0'
 description      'Installs/configures squid as a simple caching proxy'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.5.2'
+version          '0.5.3'
 
 %w{debian ubuntu centos fedora redhat scientific suse amazon}.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,9 +26,9 @@ version = node['squid']['version']
 netmask = node['network']['interfaces'][listen_interface]['addresses'][ipaddress]['netmask']
 
 # squid/libraries/default.rb
-acls = squid_load_acls
-host_acl = squid_load_host_acl
-url_acl = squid_load_url_acl
+acls = squid_load_acls(node['squid']['acls_databag_name'])
+host_acl = squid_load_host_acl(node['squid']['hosts_databag_name'])
+url_acl = squid_load_url_acl(node['squid']['urls_databag_name'])
 
 # Log variables to Chef::Log::debug()
 Chef::Log.debug("Squid listen_interface: #{listen_interface}")


### PR DESCRIPTION
By defining node['squid']['xxxx_databag_name'] attributes in environment / role / node level, you can use different data bags for ACL definitions. 
