### PR TITLE
Fix #86. Remove unused network detection which break some setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is used to list changes made in each version of the squid cookbook.
 - Removed support for smartos
 - Removed Travis testing, added circleci testing
 - Add attribute to set CONNECT and safe_ports restriction optionnal
+- Remove unused network detection which break some setups
 
 ## 4.1.0 (2018-05-23)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,8 +46,6 @@ default['squid']['enable_connect_restriction'] = true
 default['squid']['http_access_deny_all'] = true
 default['squid']['icp_access_deny_all'] = true
 
-default['squid']['ipaddress'] = node['ipaddress']
-default['squid']['listen_interface'] = node['network']['interfaces'].dup.reject { |k, v| k == 'lo' || v[:state] == 'down' }.keys.first
 default['squid']['cache_mem'] = '2048'
 default['squid']['cache_size'] = '100'
 default['squid']['max_obj_size'] = 1024
@@ -86,9 +84,6 @@ when 'debian'
     default['squid']['cache_dir'] = '/var/spool/squid'
     default['squid']['coredump_dir'] = '/var/spool/squid'
   end
-
-when 'smartos'
-  default['squid']['listen_interface'] = 'net0'
 
 when 'freebsd'
   default['squid']['config_dir'] = '/usr/local/etc/squid'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,20 +17,12 @@
 # limitations under the License.
 #
 
-# variables
-ipaddress = node['squid']['ipaddress']
-listen_interface = node['squid']['listen_interface']
-netmask = node['network']['interfaces'][listen_interface]['addresses'][ipaddress]['netmask']
-
 # squid/libraries/default.rb
 acls = squid_load_acls(node['squid']['acls_databag_name'])
 host_acl = squid_load_host_acl(node['squid']['hosts_databag_name'])
 url_acl = squid_load_url_acl(node['squid']['urls_databag_name'])
 
 # Log variables to Chef::Log::debug()
-Chef::Log.debug("Squid listen_interface: #{listen_interface}")
-Chef::Log.debug("Squid ipaddress: #{ipaddress}")
-Chef::Log.debug("Squid netmask: #{netmask}")
 Chef::Log.debug("Squid host_acls: #{host_acl}")
 Chef::Log.debug("Squid url_acls: #{url_acl}")
 Chef::Log.debug("Squid acls: #{acls}")


### PR DESCRIPTION
### Description

listen_interface detection fail if you have one interface up without
address, like the main interface in a setup with vlan.

### Issues Resolved

#86 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

(All test failed unrelated)