### PR TITLE
Use the new kitchen orb (1.0.2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 version: 2.1
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  kitchen: sous-chefs/kitchen@1.0.0
+  kitchen: sous-chefs/kitchen@1.0.2
 
 workflows:
   kitchen:
@@ -10,8 +10,8 @@ workflows:
           name: danger
           context: Danger
       - kitchen/lint:
-          name: lint
+          name: delivery
       - kitchen/dokken:
           name: default-suite
           suite: default
-          requires: [ lint, danger ]
+          requires: [delivery, danger]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - kitchen/danger:
           name: danger
           context: Danger
-      - kitchen/lint:
+      - kitchen/delivery:
           name: delivery
       - kitchen/dokken:
           name: default-suite


### PR DESCRIPTION
### Description

We should use the new kitchen orb, as we've updated the supported platform and renamed a stage to make more sense

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
