### PR TITLE
Moves squid version code to helper

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -5,6 +5,8 @@ driver:
 provisioner:
   name: chef_zero
   deprecations_as_errors: true
+  multiple_converge: 2
+  enforce_idempotency: true
 
 verifier:
   name: inspec

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -56,6 +56,12 @@ module ChefSquidHelpers
       'squid'
     end
   end
+
+  def squid_version_detected
+    command = %(#{node['squid']['package']} -v | grep Version | sed 's/.*Version \\\(.\\..\\\).*/\\1/g' | tr -d '\n')
+    command_out = shell_out(command)
+    command_out.stdout.to_f
+  end
 end
 
 Chef::Resource.send(:include, ChefSquidHelpers)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,15 +30,6 @@ Chef::Log.debug("Squid acls: #{acls}")
 # packages
 package node['squid']['package']
 
-ruby_block 'Detect squid version' do
-  block do
-    Chef::Resource::RubyBlock.send(:include, Chef::Mixin::ShellOut)
-    command = %(#{node['squid']['package']} -v | grep Version | sed 's/.*Version \\\(.\\..\\\).*/\\1/g' | tr -d '\n')
-    command_out = shell_out(command)
-    node.normal['squid']['squid_version_detected'] = command_out.stdout.to_f
-  end
-end
-
 # rhel_family sysconfig
 template '/etc/sysconfig/squid' do
   source 'redhat/sysconfig/squid.erb'
@@ -102,7 +93,7 @@ template node['squid']['config_file'] do
         log_module: node['squid']['log_module'],
         safe_ports: node['squid']['safe_ports'],
         ssl_ports: node['squid']['ssl_ports'],
-        version: node['squid']['squid_version_detected'],
+        version: squid_version_detected,
       }
     end
   )

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -104,7 +104,7 @@ execute 'initialize squid cache dir' do
   command "#{node['squid']['package']} -Nz"
   action :run
   creates ::File.join(node['squid']['cache_dir'], '00')
-  not_if { node['platform_family'] =~ /(rhel|fedora)/ }
+  not_if do FileTest.directory?("#{node['squid']['cache_dir']}/00") end
 end
 
 # services

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -104,7 +104,7 @@ execute 'initialize squid cache dir' do
   command "#{node['squid']['package']} -Nz"
   action :run
   creates ::File.join(node['squid']['cache_dir'], '00')
-  not_if do FileTest.directory?("#{node['squid']['cache_dir']}/00") end
+  not_if { FileTest.directory?("#{node['squid']['cache_dir']}/00") }
 end
 
 # services

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,117 +1,120 @@
 require 'spec_helper'
 
-describe 'squid::default on Ubuntu 16.04' do
-  cached(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04') do
-    end.converge('squid::default')
-  end
-
-  it 'installs package squid' do
-    expect(chef_run).to install_package('squid')
-  end
-
-  it 'templates /etc/squid/squid.conf' do
-    expect(chef_run).to create_template('/etc/squid/squid.conf')
-  end
-
-  it 'templates /etc/squid/squid.conf http deny all' do
-    expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
-      'http_access deny all'
-    )
-  end
-
-  it 'templates /etc/squid/squid.conf icp deny all' do
-    expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
-      'icp_access deny all'
-    )
-  end
-
-  it 'templates /etc/squid/squid.conf without include directory' do
-    expect(chef_run).to_not render_file('/etc/squid/squid.conf').with_content(
-      'Include additional configuration files'
-    )
-  end
-
-  it 'file /etc/squid/conf.d/dummy.conf' do
-    expect(chef_run).to_not create_file('/etc/squid/conf.d/dummy.conf')
-  end
-
-  it 'directory /etc/squid/conf.d/' do
-    expect(chef_run).to_not create_directory('/etc/squid/conf.d')
-  end
-end
-
-describe 'squid::default on CentOS 6' do
-  cached(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'centos', version: '6') do
-    end.converge('squid::default')
-  end
-
-  it 'installs package squid' do
-    expect(chef_run).to install_package('squid')
-  end
-
-  it 'templates /etc/sysconfig/squid' do
-    expect(chef_run).to create_template('/etc/sysconfig/squid')
-  end
-
-  it 'templates /etc/squid/squid.conf' do
-    expect(chef_run).to create_template('/etc/squid/squid.conf')
-  end
-
-  it 'templates /etc/squid/squid.conf http deny all' do
-    expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
-      'http_access deny all'
-    )
-  end
-
-  it 'templates /etc/squid/squid.conf icp deny all' do
-    expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
-      'icp_access deny all'
-    )
-  end
-
-  it 'templates /etc/squid/squid.conf without include directory' do
-    expect(chef_run).to_not render_file('/etc/squid/squid.conf').with_content(
-      'Include additional configuration files'
-    )
-  end
-
-  it 'file /etc/squid/conf.d/dummy.conf' do
-    expect(chef_run).to_not create_file('/etc/squid/conf.d/dummy.conf')
-  end
-
-  it 'directory /etc/squid/conf.d/' do
-    expect(chef_run).to_not create_directory('/etc/squid/conf.d')
-  end
-end
-
-describe 'squid::default with squid_acl databag entries set on CentOS 6' do
-  let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'centos', version: '6') do
-    end.converge('squid::default')
-  end
-
+describe 'squid::default' do
   before do
-    # Required to make spec pass
-    # https://github.com/sethvargo/chefspec/issues/260
-    stub_command('/etc/squid/conf.d').and_return(false)
-    stub_data_bag('squid_acls').and_return(['my-acl'])
-    stub_data_bag_item('squid_acls', 'my-acl').and_return(
-      "id": 'my-acl',
-      "acl": [['', 'allow'], ['', 'deny', '!']]
-    )
+    stubs_for_resource("template[/etc/squid/squid.conf]") do |resource|
+      allow(resource).to receive_shell_out("squid -v | grep Version | sed 's/.*Version \\(.\\..\\).*/\\1/g' | tr -d '\n'")
+    end
   end
 
-  it 'templates /etc/squid/squid.conf with content http_access allow my-acl' do
-    expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
-      'http_access allow my-acl'
-    )
+  context 'When all attributes are default, on an Ubuntu 16.04' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04')
+        .converge(described_recipe)
+    end
+
+    it 'installs package squid' do
+      expect(chef_run).to install_package('squid')
+    end
+
+    it 'templates /etc/squid/squid.conf' do
+      expect(chef_run).to create_template('/etc/squid/squid.conf')
+    end
+
+    it 'templates /etc/squid/squid.conf http deny all' do
+      expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
+        'http_access deny all'
+      )
+    end
+
+    it 'templates /etc/squid/squid.conf icp deny all' do
+      expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
+        'icp_access deny all'
+      )
+    end
+
+    it 'templates /etc/squid/squid.conf without include directory' do
+      expect(chef_run).to_not render_file('/etc/squid/squid.conf').with_content(
+        'Include additional configuration files'
+      )
+    end
+
+    it 'file /etc/squid/conf.d/dummy.conf' do
+      expect(chef_run).to_not create_file('/etc/squid/conf.d/dummy.conf')
+    end
+
+    it 'directory /etc/squid/conf.d/' do
+      expect(chef_run).to_not create_directory('/etc/squid/conf.d')
+    end
   end
 
-  it 'templates /etc/squid/squid.conf with content http_access deny !my-acl' do
-    expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
-      'http_access deny !my-acl'
-    )
+  context 'When all attributes are default, on an Centos 6' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6')
+        .converge(described_recipe)
+    end
+
+    it 'installs package squid' do
+      expect(chef_run).to install_package('squid')
+    end
+
+    it 'templates /etc/sysconfig/squid' do
+      expect(chef_run).to create_template('/etc/sysconfig/squid')
+    end
+
+    it 'templates /etc/squid/squid.conf' do
+      expect(chef_run).to create_template('/etc/squid/squid.conf')
+    end
+
+    it 'templates /etc/squid/squid.conf http deny all' do
+      expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
+        'http_access deny all'
+      )
+    end
+
+    it 'templates /etc/squid/squid.conf icp deny all' do
+      expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
+        'icp_access deny all'
+      )
+    end
+
+    it 'templates /etc/squid/squid.conf without include directory' do
+      expect(chef_run).to_not render_file('/etc/squid/squid.conf').with_content(
+        'Include additional configuration files'
+      )
+    end
+
+    it 'file /etc/squid/conf.d/dummy.conf' do
+      expect(chef_run).to_not create_file('/etc/squid/conf.d/dummy.conf')
+    end
+
+    it 'directory /etc/squid/conf.d/' do
+      expect(chef_run).to_not create_directory('/etc/squid/conf.d')
+    end
+
+    context 'With squid_acl databag entries' do
+      before do
+        # Required to make spec pass
+        # https://github.com/sethvargo/chefspec/issues/260
+        stub_command('/etc/squid/conf.d').and_return(false)
+        stub_data_bag('squid_acls').and_return(['my-acl'])
+        stub_data_bag_item('squid_acls', 'my-acl').and_return(
+          "id": 'my-acl',
+          "acl": [['', 'allow'], ['', 'deny', '!']]
+        )
+      end
+
+      it 'templates /etc/squid/squid.conf with content http_access allow my-acl' do
+        expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
+          'http_access allow my-acl'
+        )
+      end
+
+      it 'templates /etc/squid/squid.conf with content http_access deny !my-acl' do
+        expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
+          'http_access deny !my-acl'
+        )
+      end
+    end
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'squid::default' do
   before do
-    stubs_for_resource("template[/etc/squid/squid.conf]") do |resource|
+    stubs_for_resource('template[/etc/squid/squid.conf]') do |resource|
       allow(resource).to receive_shell_out("squid -v | grep Version | sed 's/.*Version \\(.\\..\\).*/\\1/g' | tr -d '\n'")
     end
   end
@@ -10,7 +10,7 @@ describe 'squid::default' do
   context 'When all attributes are default, on an Ubuntu 16.04' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04')
-        .converge(described_recipe)
+                          .converge(described_recipe)
     end
 
     it 'installs package squid' do
@@ -51,7 +51,7 @@ describe 'squid::default' do
   context 'When all attributes are default, on an Centos 6' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '6')
-        .converge(described_recipe)
+                          .converge(described_recipe)
     end
 
     it 'installs package squid' do


### PR DESCRIPTION
# Description

This MR removes ruby_block[Detect squid version] resource to a helper method which prevents it   from running at every converge and therefore fixes the idemptoncy issue.

## Issues Resolved

#112

## Check List

- [x] All tests pass. See TESTING.md for details.
