### PR TITLE
Add support for Debian 10 / Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,13 @@ jobs:
       matrix:
         os:
           - 'amazonlinux-2'
-          - 'debian-8'
           - 'debian-9'
+          - 'debian-10'
           - 'centos-7'
+          - 'centos-8'
           - 'ubuntu-1604'
           - 'ubuntu-1804'
+          - 'ubuntu-2004'
         suite:
           - 'default'
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the squid cookbook.
 
+## Unreleased
+
+- Add Debian 10 / Ubuntu 20.04 support
+- Add testing on Centos 8
+- Remove testing on Debian 8 and Centos 6
+
 ## 4.3.1 (2020-09-16)
 
 - resolved cookstyle error: libraries/helpers.rb:68:1 refactor: `ChefCorrectness/IncorrectLibraryInjection`

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Platforms
 
-- Debian 7+
-- Ubuntu 12.04+
-- RHEL/CentOS/Amazon/Scientific 6+
+- Debian 9+
+- Ubuntu 16.04+
+- RHEL/CentOS/Amazon/Scientific 7+
 - openSUSE / openSUSE Leap
 - FreeBSD 11+
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -21,13 +21,6 @@ platforms:
       image: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-8
-    driver:
-      image: dokken/debian-8
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
   - name: debian-9
     driver:
       image: dokken/debian-9
@@ -35,9 +28,21 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
 
+  - name: debian-10
+    driver:
+      image: dokken/debian-10
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+
   - name: centos-7
     driver:
       image: dokken/centos-7
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: centos-8
+    driver:
+      image: dokken/centos-8
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: ubuntu-16.04
@@ -50,6 +55,13 @@ platforms:
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+
+  - name: ubuntu-20.04
+    driver:
+      image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,15 +15,17 @@ platforms:
   - name: amazonlinux
     driver_config:
       box: mvbcoding/awslinux
-  - name: centos-6
+  - name: amazonlinux-2
   - name: centos-7
-  - name: debian-8
+  - name: centos-8
   - name: debian-9
-  - name: fedora-28
+  - name: debian-10
+  - name: fedora-33
   - name: freebsd-11
   - name: opensuse-leap-42
   - name: ubuntu-16.04
   - name: ubuntu-18.04
+  - name: ubuntu-20.04
 
 suites:
   - name: default

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -104,6 +104,8 @@ execute 'initialize squid cache dir' do
   command "#{node['squid']['package']} -Nz"
   action :run
   creates ::File.join(node['squid']['cache_dir'], '00')
+  notifies :stop, "service[#{squid_service_name}]", :before
+  notifies :start, "service[#{squid_service_name}]"
   not_if { FileTest.directory?("#{node['squid']['cache_dir']}/00") }
 end
 

--- a/test/integration/default/squid_spec.rb
+++ b/test/integration/default/squid_spec.rb
@@ -5,6 +5,12 @@ describe port(3128) do
   it { should be_listening }
 end
 
+cache_dir = os.linux? ? '/var/spool/squid' : '/var/squid/cache'
+
+describe directory("#{cache_dir}/00") do
+  it { should exist }
+end
+
 # This would be great, but it needs a lot more logic to work properly
 # squid_syntax_check = 'sudo squid -k parse'
 # squid_syntax_check = 'sudo squid3 -k parse' if os[:family] == 'debian'


### PR DESCRIPTION
# Description

The problem is cache initialization cannot run while squid is running. Older versions of squid silently failed but the version in Debian 10 / Ubuntu 20.04 returns an error. To solve this we stop squid before running cache init.

Also drop support for EOL OS's and add support for new ones.

## Issues Resolved

Fixes #134 .

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
