### PR TITLE
Don't try to create cache_dir if caching is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the squid cookbook.
 
 ## Unreleased
 
+- Fix squid stopping and starting on every run if caching is disabled
+
 ## 4.4.1 - *2021-06-01*
 
 ## 4.4.0 - *2021-01-10*

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -107,6 +107,7 @@ execute 'initialize squid cache dir' do
   notifies :stop, "service[#{squid_service_name}]", :before
   notifies :start, "service[#{squid_service_name}]"
   not_if { FileTest.directory?("#{node['squid']['cache_dir']}/00") }
+  only_if { node['squid']['enable_cache_dir'] }
 end
 
 # services


### PR DESCRIPTION

# Description

If caching isn't used (e.g. `node['squid']['enable_cache_dir'] = false`) then squid is stopped and started on every run. Now we only create the cache dir when caching is enabled.

Signed-off-by: Eric Heydrick <eheydrick@gmail.com>

## Issues Resolved

Fixes #138 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
