### PR TITLE
Update the test matrix to include modern distros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,21 @@ jobs:
     strategy:
       matrix:
         os:
-          - "amazonlinux-2"
-          - "debian-9"
-          - "debian-10"
+          - "almalinux-8"
+          - "almalinux-9"
           - "centos-7"
-          - "centos-8"
-          - "ubuntu-1604"
+          - "centos-stream-8"
+          - "centos-stream-9"
+          - "debian-10"
+          - "debian-11"
+          - "debian-12"
+          - "oraclelinux-8"
+          - "oraclelinux-9"
+          - "rockylinux-8"
+          - "rockylinux-9"
           - "ubuntu-1804"
           - "ubuntu-2004"
+          - "ubuntu-2204"
         suite:
           - "default"
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the squid cookbook.
 
 ## Unreleased
 
+- Remove support for EOL Debian 9 distribution.
+- Add testing for modern Linux distributions.
+
 ## 5.0.0 - *2023-05-09*
 
 - Remove support for EOL Ubuntu 14.04 and Debian 8 distributions

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Platforms
 
-- Debian 9+
+- Debian 10+
 - Ubuntu 16.04+
-- RHEL/CentOS/Amazon/Scientific 7+
+- RHEL/CentOS/Scientific 7+
 - openSUSE / openSUSE Leap
 - FreeBSD 11+
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -16,52 +16,81 @@ verifier:
   name: inspec
 
 platforms:
-  - name: amazonlinux-2
+  - name: almalinux-8
     driver:
-      image: dokken/amazonlinux-2
+      image: dokken/almalinux-8
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-9
+  - name: almalinux-9
     driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
-  - name: debian-10
-    driver:
-      image: dokken/debian-10
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+      image: dokken/almalinux-9
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: centos-7
     driver:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-8
+  - name: centos-stream-8
     driver:
-      image: dokken/centos-8
+      image: dokken/centos-stream-8
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: ubuntu-16.04
+  - name: centos-stream-9
     driver:
-      image: dokken/ubuntu-16.04
+      image: dokken/centos-stream-9
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: debian-10
+    driver:
+      image: dokken/debian-10
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      pid_one_command: /bin/systemd
+
+  - name: debian-12
+    driver:
+      image: dokken/debian-12
+      pid_one_command: /bin/systemd
+  - name: oraclelinux-7
+    driver:
+      image: dokken/oraclelinux-7
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: oraclelinux-8
+    driver:
+      image: dokken/oraclelinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: oraclelinux-9
+    driver:
+      image: dokken/oraclelinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-9
+    driver:
+      image: dokken/rockylinux-9
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+
+  - name: ubuntu-22.04
+    driver:
+      image: dokken/ubuntu-22.04
+      pid_one_command: /bin/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -12,20 +12,17 @@ verifier:
   name: inspec
 
 platforms:
-  - name: amazonlinux
-    driver_config:
-      box: mvbcoding/awslinux
-  - name: amazonlinux-2
   - name: centos-7
-  - name: centos-8
-  - name: debian-9
+  - name: centos-stream-8
+  - name: centos-stream-9
   - name: debian-10
-  - name: fedora-33
-  - name: freebsd-11
+  - name: debian-11
+  - name: fedora-latest
+  - name: freebsd-13
   - name: opensuse-leap-42
-  - name: ubuntu-16.04
   - name: ubuntu-18.04
   - name: ubuntu-20.04
+  - name: ubuntu-22.04
 
 suites:
   - name: default

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -7,9 +7,9 @@ describe 'squid::default' do
     end
   end
 
-  context 'When all attributes are default, on an Ubuntu 16.04' do
+  context 'When all attributes are default, on an Ubuntu 20.04' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04')
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '20.04')
                           .converge(described_recipe)
     end
 
@@ -48,9 +48,9 @@ describe 'squid::default' do
     end
   end
 
-  context 'When all attributes are default, on an Centos 6' do
+  context 'When all attributes are default, on an CentOS 8' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: '6')
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '8')
                           .converge(described_recipe)
     end
 


### PR DESCRIPTION
Remove support for Debian 9 since a simple apt-get update there fails now. No way to test this. Remove amazon from the readme as Amazon Linux 2023 no longer includes squid: https://docs.aws.amazon.com/linux/al2023/release-notes/removed-packages.html